### PR TITLE
readme: Use relative links for project files

### DIFF
--- a/1_data_gather/README.md
+++ b/1_data_gather/README.md
@@ -1,5 +1,5 @@
 ## AniList Data Gathering
 
-*NOTE: see the [full project readme for additional context](https://github.com/NoMoreRoads/Manga-Demographic-Prediction/tree/main); this is a sub-project of a larger undertaking.*
+*NOTE: see the [full project readme for additional context](/README.md); this is a sub-project of a larger undertaking.*
 
 This script sends iterative requests to the [AniList API](https://anilist.gitbook.io/anilist-apiv2-docs/overview/graphql/getting-started) containing queries written in GraphQL, in order to scrape the API for data on manga listed on the site within specified paramters (over 200 people have it on their "list", it is not considered "adult"). The queried information is then wrangled into a more recognizably rectangular format, rather than the graph structure it is intially returned in. This rectangular structure is placed into a pandas dataframe, and then exported as a csv for further processing.

--- a/2_data_explore/README.md
+++ b/2_data_explore/README.md
@@ -1,6 +1,6 @@
 ## Data Exploration
 
-*NOTE: see the [full project readme for additional context](https://github.com/NoMoreRoads/Manga-Demographic-Prediction/tree/main); this is a sub-project of a larger undertaking.*
+*NOTE: see the [full project readme for additional context](/README.md); this is a sub-project of a larger undertaking.*
 
 This Jupyter Notebook utilizes Pandas and other Python libraries to explore the data obtained from AniList, with an eye towards imputing missing values, feature engineering, and eventually leveraging classification algorithms to predict the demographic label. 
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ This repository contains a script for scraping the API maintained by the media c
 
 This project has been divided up into several sub-projects, each with their own directory in the repository, for clarity.
 
-### [Data Gathering](https://github.com/NoMoreRoads/Manga-Demographic-Prediction/tree/main/1_data_gather)
+### [Data Gathering](./1_data_gather)
 
 This script sends iterative requests to the [AniList API](https://anilist.gitbook.io/anilist-apiv2-docs/overview/graphql/getting-started) containing queries written in GraphQL, in order to scrape the API for data on manga listed on the site within specified paramters (over 200 people have it on their "list", it is not considered "adult"). The queried information is then wrangled into a more recognizably rectangular format, rather than the graph structure it is intially returned in. This rectangular structure is placed into a pandas dataframe, and then exported as a csv for further processing.
 
-### [Data Exploration](https://github.com/NoMoreRoads/Manga-Demographic-Prediction/tree/main/2_data_explore)
+### [Data Exploration](./2_data_explore)
 
 This Jupyter Notebook utilizes Pandas and other Python libraries to explore the data obtained from AniList, with an eye towards imputing missing values, feature engineering, and eventually leveraging classification algorithms to predict the demographic label. 
 


### PR DESCRIPTION
This ensures that the links continue to work in project forks and in local checkouts.This ensures that the links continue to work in project forks and in local checkouts.