### PR TITLE
Better formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,9 @@
 # To use this config on you editor, follow the instructions at:
 # http://editorconfig.org
 
+# Keys marked as 'unsupported' below are not supported by EditorConfig and merely serve as documentation. For Vim,
+# a top-level '.vimrc' is provided. For other editors, the setting must be configured manually.
+
 root = true
 
 # All Files
@@ -11,9 +14,10 @@ end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-# Text Docs
-[*.{txt,md,markdown}]
+# Text Docs and Config Files
+[*.txt,*.md,*.markdown,README,README.*,.editorconfig]
 indent_size = 4
+# unsupported: text_width = 120
 
 # Python
 [{*.py,data_gather,tags_gather}]
@@ -22,6 +26,9 @@ indent_size = 4
 # Jupyter Notebook JSON
 [*.ipynb]
 indent_size = 1
+
+[.vimrc,*.vim]
+indent_size = 2
 
 [*.json]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# To use this config on you editor, follow the instructions at:
+# http://editorconfig.org
+
+root = true
+
+# All Files
+[*]
+charset = utf-8
+indent_style = space
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# Text Docs
+[*.{txt,md,markdown}]
+indent_size = 4
+
+# Python
+[{*.py,data_gather,tags_gather}]
+indent_size = 4
+
+# Jupyter Notebook JSON
+[*.ipynb]
+indent_size = 1
+
+[*.json]
+indent_size = 2

--- a/.vimrc
+++ b/.vimrc
@@ -1,0 +1,3 @@
+autocmd FileType text set textwidth=120
+autocmd FileType markdown set textwidth=120
+autocmd FileType editorconfig set textwidth=120

--- a/1_data_gather/README.md
+++ b/1_data_gather/README.md
@@ -2,6 +2,13 @@
 
 *NOTE: see the [full project readme for additional context](/README.md); this is a sub-project of a larger undertaking.*
 
-The data gather script sends iterative requests to the [AniList API](https://anilist.gitbook.io/anilist-apiv2-docs/overview/graphql/getting-started) containing queries written in GraphQL, in order to scrape the API for data on manga listed on the site within specified parameters (over 200 people have it on their "list", it is not considered "adult"). The queried information is then wrangled into a more recognizably rectangular format, rather than the graph structure it is intially returned in. This rectangular structure is placed into a pandas dataframe, and then exported as a csv for further processing.
+The data gather script sends iterative requests to the
+[AniList API](https://anilist.gitbook.io/anilist-apiv2-docs/overview/graphql/getting-started) containing queries written
+in GraphQL, in order to scrape the API for data on manga listed on the site within specified parameters (over 200 people
+have it on their "list", it is not considered "adult"). The queried information is then wrangled into a more
+recognizably rectangular format, rather than the graph structure it is intially returned in. This rectangular structure
+is placed into a pandas dataframe, and then exported as a csv for further processing.
 
-The tag gather script queries the Anilist API for the full list of media tags (excluding adult tags) with their associated descriptions, formats the result, converts it to pandas dataframe format, and exports the result as a csv which serves as an appendix to the data dictionary.
+The tag gather script queries the Anilist API for the full list of media tags (excluding adult tags) with their
+associated descriptions, formats the result, converts it to pandas dataframe format, and exports the result as a csv
+which serves as an appendix to the data dictionary.

--- a/2_data_explore/README.md
+++ b/2_data_explore/README.md
@@ -2,6 +2,9 @@
 
 *NOTE: see the [full project readme for additional context](/README.md); this is a sub-project of a larger undertaking.*
 
-This Jupyter Notebook utilizes Pandas and other Python libraries to explore the data obtained from AniList, with an eye towards imputing missing values, feature engineering, and eventually leveraging classification algorithms to predict the demographic label. 
+This Jupyter Notebook utilizes Pandas and other Python libraries to explore the data obtained from AniList, with an eye
+towards imputing missing values, feature engineering, and eventually leveraging classification algorithms to predict the
+demographic label.
 
-The notebook also performs some data wrangling tasks, as the data extracted from the API is not fully formatted the way we need to perform useful analysis.
+The notebook also performs some data wrangling tasks, as the data extracted from the API is not fully formatted the way
+we need to perform useful analysis.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,28 @@
 # Anilist Demographic Prediction Project
 
-This repository contains a script for scraping the API maintained by the media cataloging service AniList for a large volume of manga listings. From there code will be used to explore the data, engineer new features, and use a random forest classifier to predict the demographic label of a given manga based on its features.
+This repository contains a script for scraping the API maintained by the media cataloging service AniList for a large
+volume of manga listings. From there code will be used to explore the data, engineer new features, and use a random
+forest classifier to predict the demographic label of a given manga based on its features.
 
 ### Key concepts
 
-[Manga](https://en.wikipedia.org/wiki/Manga) is a type of comic originating from Japan, although AniList uses the term more broadly to also refer to similar works published in Korea, China, and Taiwan.
+[Manga](https://en.wikipedia.org/wiki/Manga) is a type of comic originating from Japan, although AniList uses the term
+more broadly to also refer to similar works published in Korea, China, and Taiwan.
 
-[AniList](https://anilist.co) is a media tracking site for anime and manga, similar to what [Goodreads](https://www.goodreads.com/) is for books or [Letterboxd](https://letterboxd.com/) is for movies. The site relies largely on user contributions to add new listings and provide up-to-date information for existing listings, although it has a team of moderators to check user contributions as well.
+[AniList](https://anilist.co) is a media tracking site for anime and manga, similar to what
+[Goodreads](https://www.goodreads.com/) is for books or [Letterboxd](https://letterboxd.com/) is for movies. The site
+relies largely on user contributions to add new listings and provide up-to-date information for existing listings,
+although it has a team of moderators to check user contributions as well.
 
-[Manga Demographic Groups](https://en.wikipedia.org/wiki/Sh%C5%8Dnen_manga) refer to the way manga magazine publishers in Japan categorize their magazines by the presumed demographic audience they are attempting to reach. In general, "shounen" is intended for adolescent boys, "shoujo" is intended for adolescent girls, "josei" is intended for adult women, and "seinen" is intended for adult men. The actual readership of these works is often more diverse than these labels suggest, and some have suggested that the meaning of these categories has changed over time, and more suggest a sort of "genre" rather than explicitly attemtping to reach one sort of reader.
+[Manga Demographic Groups](https://en.wikipedia.org/wiki/Sh%C5%8Dnen_manga) refer to the way manga magazine publishers
+in Japan categorize their magazines by the presumed demographic audience they are attempting to reach. In general,
+"shounen" is intended for adolescent boys, "shoujo" is intended for adolescent girls, "josei" is intended for adult
+women, and "seinen" is intended for adult men. The actual readership of these works is often more diverse than these
+labels suggest, and some have suggested that the meaning of these categories has changed over time, and more suggest
+a sort of "genre" rather than explicitly attemtping to reach one sort of reader.
 
-This project includes a [data dictionary](./data/data_dictionary.md) in order to provide a more detailed look into the individual features contained within the data set.
+This project includes a [data dictionary](./data/data_dictionary.md) in order to provide a more detailed look into the
+individual features contained within the data set.
 
 ## Sub-projects
 
@@ -18,13 +30,25 @@ This project has been divided up into several sub-projects, each with their own 
 
 ### [Data Gathering](./1_data_gather)
 
-The data gather script sends iterative requests to the [AniList API](https://anilist.gitbook.io/anilist-apiv2-docs/overview/graphql/getting-started) containing queries written in GraphQL, in order to scrape the API for data on manga listed on the site within specified parameters (over 200 people have it on their "list", it is not considered "adult"). The queried information is then wrangled into a more recognizably rectangular format, rather than the graph structure it is intially returned in. This rectangular structure is placed into a pandas dataframe, and then exported as a csv for further processing.
+The data gather script sends iterative requests to the
+[AniList API](https://anilist.gitbook.io/anilist-apiv2-docs/overview/graphql/getting-started) containing queries written
+in GraphQL, in order to scrape the API for data on manga listed on the site within specified parameters (over 200 people
+have it on their "list", it is not considered "adult"). The queried information is then wrangled into a more
+recognizably rectangular format, rather than the graph structure it is intially returned in. This rectangular structure
+is placed into a pandas dataframe, and then exported as a csv for further processing.
 
-The tag gather script queries the Anilist API for the full list of media tags (excluding adult tags) with their associated descriptions, formats the result, converts it to pandas dataframe format, and exports the result as a csv which serves as an appendix to the data dictionary.
+The tag gather script queries the Anilist API for the full list of media tags (excluding adult tags) with their
+associated descriptions, formats the result, converts it to pandas dataframe format, and exports the result as a csv
+which serves as an appendix to the data dictionary.
 
 ### [Data Exploration](./2_data_explore)
 
-This Jupyter Notebook utilizes Pandas and other Python libraries to explore the data obtained from AniList, with an eye towards imputing missing values, feature engineering, and eventually leveraging classification algorithms to predict the demographic label. 
+This Jupyter Notebook utilizes Pandas and other Python libraries to explore the data obtained from AniList, with an eye
+towards imputing missing values, feature engineering, and eventually leveraging classification algorithms to predict the
+demographic label.
+
+The notebook also performs some data wrangling tasks, as the data extracted from the API is not fully formatted the way
+we need to perform useful analysis.
 
 The notebook also performs some data wrangling tasks, as the data extracted from the API is not fully formatted the way we need to perform useful analysis.
 

--- a/data/data_dictionary.md
+++ b/data/data_dictionary.md
@@ -104,8 +104,8 @@ Sports, Supernatural, and Thriller.
 **\[tag\]**\
 A series of features indicating the score (0 to 100, inclusive) users have given to a given tag \[tag\]. The score is
 meant to represent how central a theme the tag is to the work, where zero indicates that no user has submitted the tag
-to the work, and 100 indicates that it is a central theme. **The site-generated descriptions of each tag are enumerated
-in the appendix to this data dictionary, which can be accessed [here](../data/tag_reference.csv).**
+to the work, and 100 indicates that it is a central theme. *The site-generated descriptions of each tag are enumerated
+in the appendix to this data dictionary, which can be accessed [here](../data/tag_reference.csv).*
 
 **relation_\[relationtype\]**\
 A feature indicating the number of related media that are related in a given way \[relationtype\]. Examples may include

--- a/data/data_dictionary.md
+++ b/data/data_dictionary.md
@@ -1,10 +1,15 @@
 # Data Dictionary
 
-Note that the information listed here is derived from a combination of [AniList's API documentation](https://anilist.github.io/ApiV2-GraphQL-Docs/) and domain knowledge of the author, where the former source does not give clear documentation on the meaning of raw data.
+Note that the information listed here is derived from a combination of
+[AniList's API documentation](https://anilist.github.io/ApiV2-GraphQL-Docs/) and domain knowledge of the author, where
+the former source does not give clear documentation on the meaning of raw data.
 
-The appendix to this data dictionary, which includes the site-generated descriptions of all "tag" features, can be accessed [here](../data/tag_reference.csv)
+The appendix to this data dictionary, which includes the site-generated descriptions of all "tag" features, can be
+accessed [here](../data/tag_reference.csv)
 
-*note that for all features involving characters, a limiatation of the current data collection process is that only 50 of each character role type (main, supporting, and background) are collected. For media with more than 50 of any one of these roles listed, the count may be artificially limited.*
+*Note that for all features involving characters, a limiatation of the current data collection process is that only 50
+of each character role type (main, supporting, and background) are collected. For media with more than 50 of any one of
+these roles listed, the count may be artificially limited.*
 
 ## Static Feature Names
 The following are features whose names are hard-coded during the data collection process.
@@ -13,7 +18,8 @@ The following are features whose names are hard-coded during the data collection
 A unique identifier for each manga entry.
 
 ### eng_title:
-The official english-language title for the manga. Usually if blank, indicates that the work has not been licensed and officially released in the English-speaking world.
+The official english-language title for the manga. Usually if blank, indicates that the work has not been licensed and
+officially released in the English-speaking world.
 
 ### rom_title:
 The native-language title in romaji (in other words, the native title written phonetically in the roman alphabet).
@@ -22,7 +28,8 @@ The native-language title in romaji (in other words, the native title written ph
 The number of AniList users who have the manga on their “list”.
 
 ### mean_score:
-Users can give a score ranging from 1 to 100 (inclusive) to a manga. This measure reports the mean for all users who have scored the manga.
+Users can give a score ranging from 1 to 100 (inclusive) to a manga. This measure reports the mean for all users who
+have scored the manga.
 
 ### status:
 The release status of the media-- for instance if it has not yet begun serialization, or if it has been completed.
@@ -61,34 +68,52 @@ The type of media the work is an adaptation of. If it is not an adaptation of an
 The country of origin of the work.
 
 ### total_main_roles;
-The number of characters AniList users have associated with the work who are listed as having a "main" cast role in the work.
+The number of characters AniList users have associated with the work who are listed as having a "main" cast role in the
+work.
 
 ### total_supporting_roles:
-The number of characters AniList users have associated with the work who are listed as having a "supporting" cast role in the work.
+The number of characters AniList users have associated with the work who are listed as having a "supporting" cast role
+in the work.
 
 ### total_background_roles:
-The number of characters AniList users have associated with the work who are listed as having a "supporting" cast role in the work.
+The number of characters AniList users have associated with the work who are listed as having a "supporting" cast role
+in the work.
 
 ## Dynamic Feature Names
-The following are features whose names are not hard-coded during the data collection process, but rather are named according to some programmatic process. The names given here may not match the feature names present in the data, but some explanation will be given as to the format of the name. Dyanmic portions of the tag name will be enclosed in square brackets \[\].
+The following are features whose names are not hard-coded during the data collection process, but rather are named
+according to some programmatic process. The names given here may not match the feature names present in the data, but
+some explanation will be given as to the format of the name. Dyanmic portions of the tag name will be enclosed in square
+brackets \[\].
 
 ### scored_\[##\]_count:
-The number of users who have given the manga a score (bounded between 1 and 100, inclusive) that the site considers to fall within a given \[##\] bucket. AniList's precise methodology for determining these buckets is not clear.
+The number of users who have given the manga a score (bounded between 1 and 100, inclusive) that the site considers to
+fall within a given \[##\] bucket. AniList's precise methodology for determining these buckets is not clear.
 
 ### status_\[statusname\]_count:
-The number of users who have the work listed under a given status \[statusname\] on their list. Usually "PLANNING" indicates that they intend to read it, "DROPPED" indicates that they began reading the work but did not finish, etc.
+The number of users who have the work listed under a given status \[statusname\] on their list. Usually "PLANNING"
+indicates that they intend to read it, "DROPPED" indicates that they began reading the work but did not finish, etc.
 
 ### \[genre\]:
-A series of binary features indicating whether the work is listed as being of the genre \[genre\]. Genres are not mutually exclusive, and a work can be listed under multiple genres. The possible genres are: Action, Adventure, Comedy, Drama, Ecchi, Fantasy, Horror, Mahou Shoujo, Mecha, Music, Mystery, Psychological, Romance, Sci-Fi, Slice of Life, Sports, Supernatural, and Thriller.
+A series of binary features indicating whether the work is listed as being of the genre \[genre\]. Genres are not
+mutually exclusive, and a work can be listed under multiple genres. The possible genres are: Action, Adventure, Comedy,
+Drama, Ecchi, Fantasy, Horror, Mahou Shoujo, Mecha, Music, Mystery, Psychological, Romance, Sci-Fi, Slice of Life,
+Sports, Supernatural, and Thriller.
 
 ### \[tag\]:
-A series of features indicating the score (0 to 100, inclusive) users have given to a given tag \[tag\]. The score is meant to represent how central a theme the tag is to the work, where zero indicates that no user has submitted the tag to the work, and 100 indicates that it is a central theme. **the site-generated descriptions of each tag are enumerated in the appendix to this data dictionary, which can be accessed [here](../data/tag_reference.csv).**
+A series of features indicating the score (0 to 100, inclusive) users have given to a given tag \[tag\]. The score is
+meant to represent how central a theme the tag is to the work, where zero indicates that no user has submitted the tag
+to the work, and 100 indicates that it is a central theme. **The site-generated descriptions of each tag are enumerated
+in the appendix to this data dictionary, which can be accessed [here](../data/tag_reference.csv).**
 
 ### relation_\[relationtype\]:
-A feature indicating the number of related media that are related in a given way \[relationtype\]. Examples may include the number of sequels, prequels, or spinoffs a work has.
+A feature indicating the number of related media that are related in a given way \[relationtype\]. Examples may include
+the number of sequels, prequels, or spinoffs a work has.
 
 ### relationmedia_\[mediatype\]:
-A feature indicating the number of related media that are of a given format type \[meditype\]. Examples my include the number of novels related to the work, or the number of movies.
+A feature indicating the number of related media that are of a given format type \[meditype\]. Examples my include the
+number of novels related to the work, or the number of movies.
 
 ### \[gender\]_\[type\]_roles:
-The number of characters associated with the property who have a given gender \[gender\] and role type \[type\]. Note that gender can be any string, and role type can be one of "main", "supporting", or "background". Excludes characters with a missing gender value.
+The number of characters associated with the property who have a given gender \[gender\] and role type \[type\]. Note
+that gender can be any string, and role type can be one of "main", "supporting", or "background". Excludes characters
+with a missing gender value.

--- a/data/data_dictionary.md
+++ b/data/data_dictionary.md
@@ -12,108 +12,110 @@ of each character role type (main, supporting, and background) are collected. Fo
 these roles listed, the count may be artificially limited.*
 
 ## Static Feature Names
+
 The following are features whose names are hard-coded during the data collection process.
 
-### id:
+**id**\
 A unique identifier for each manga entry.
 
-### eng_title:
+**eng_title**\
 The official english-language title for the manga. Usually if blank, indicates that the work has not been licensed and
 officially released in the English-speaking world.
 
-### rom_title:
+**rom_title**\
 The native-language title in romaji (in other words, the native title written phonetically in the roman alphabet).
 
-### popularity:
+**popularity**\
 The number of AniList users who have the manga on their “list”.
 
-### mean_score:
+**mean_score**\
 Users can give a score ranging from 1 to 100 (inclusive) to a manga. This measure reports the mean for all users who
 have scored the manga.
 
-### status:
+**status**\
 The release status of the media-- for instance if it has not yet begun serialization, or if it has been completed.
 
-### chapters:
+**chapters**\
 The number of chapters a work was released in after completion, or at the point it was cancelled or put on hiatus.
 
-### volumes:
+**volumes**\
 The number of volumes the work was released in after completion, or at the point it was cancelled or put on hiatus.
 
-### start_year:
+**start_year**\
 The year the work initially released in.
 
-### start_month:
+**start_month**\
 The month the work initially released in.
 
-### start_day:
+**start_day**\
 The day the work initially released on.
 
-### end_year:
+**end_year**\
 The year the work finished or was canceled in.
 
-### end_month:
+**end_month**\
 The month the work  finished or was canceled in.
 
-### end_day:
+**end_day**\
 The day the work  finished or was canceled on.
 
-### favorites:
+**favorites**\
 The number of AniList users who have marked the manga as a "favorite".
 
-### source:
+**source**\
 The type of media the work is an adaptation of. If it is not an adaptation of another work, it is listed as "ORIGINAL".
 
-### country:
+**country**\
 The country of origin of the work.
 
-### total_main_roles;
+**total_main_roles**\
 The number of characters AniList users have associated with the work who are listed as having a "main" cast role in the
 work.
 
-### total_supporting_roles:
+**total_supporting_roles**\
 The number of characters AniList users have associated with the work who are listed as having a "supporting" cast role
 in the work.
 
-### total_background_roles:
+**total_background_roles**\
 The number of characters AniList users have associated with the work who are listed as having a "supporting" cast role
 in the work.
 
 ## Dynamic Feature Names
+
 The following are features whose names are not hard-coded during the data collection process, but rather are named
 according to some programmatic process. The names given here may not match the feature names present in the data, but
 some explanation will be given as to the format of the name. Dyanmic portions of the tag name will be enclosed in square
 brackets \[\].
 
-### scored_\[##\]_count:
+**scored_\[##\]_count**\
 The number of users who have given the manga a score (bounded between 1 and 100, inclusive) that the site considers to
 fall within a given \[##\] bucket. AniList's precise methodology for determining these buckets is not clear.
 
-### status_\[statusname\]_count:
+**status_\[statusname\]_count**\
 The number of users who have the work listed under a given status \[statusname\] on their list. Usually "PLANNING"
 indicates that they intend to read it, "DROPPED" indicates that they began reading the work but did not finish, etc.
 
-### \[genre\]:
+**\[genre\]**\
 A series of binary features indicating whether the work is listed as being of the genre \[genre\]. Genres are not
 mutually exclusive, and a work can be listed under multiple genres. The possible genres are: Action, Adventure, Comedy,
 Drama, Ecchi, Fantasy, Horror, Mahou Shoujo, Mecha, Music, Mystery, Psychological, Romance, Sci-Fi, Slice of Life,
 Sports, Supernatural, and Thriller.
 
-### \[tag\]:
+**\[tag\]**\
 A series of features indicating the score (0 to 100, inclusive) users have given to a given tag \[tag\]. The score is
 meant to represent how central a theme the tag is to the work, where zero indicates that no user has submitted the tag
 to the work, and 100 indicates that it is a central theme. **The site-generated descriptions of each tag are enumerated
 in the appendix to this data dictionary, which can be accessed [here](../data/tag_reference.csv).**
 
-### relation_\[relationtype\]:
+**relation_\[relationtype\]**\
 A feature indicating the number of related media that are related in a given way \[relationtype\]. Examples may include
 the number of sequels, prequels, or spinoffs a work has.
 
-### relationmedia_\[mediatype\]:
+**relationmedia_\[mediatype\]**\
 A feature indicating the number of related media that are of a given format type \[meditype\]. Examples my include the
 number of novels related to the work, or the number of movies.
 
-### \[gender\]_\[type\]_roles:
+**\[gender\]_\[type\]_roles**\
 The number of characters associated with the property who have a given gender \[gender\] and role type \[type\]. Note
 that gender can be any string, and role type can be one of "main", "supporting", or "background". Excludes characters
 with a missing gender value.


### PR DESCRIPTION
This patch series does:
- Adds an `.editorconfig` file.
- Wraps text files to 120 columns.
  - I can reformat to a smaller textwidth on request. But 120 is really the max.
- Improve the markdown rendering of `data_dictionary.md`.